### PR TITLE
Fix PNG export showing JPEG slider

### DIFF
--- a/src/components/image_cleaner.rs
+++ b/src/components/image_cleaner.rs
@@ -11,7 +11,25 @@ pub struct ImageCleanerProps {
 #[function_component(ImageCleaner)]
 pub fn image_cleaner(props: &ImageCleanerProps) -> Html {
     let image_quality = use_state(|| 0.9);
-    let selected_format = use_state(|| "jpeg".to_string());
+    let initial_format = if props.image_data.mime_type == "image/png" {
+        "png".to_string()
+    } else {
+        "jpeg".to_string()
+    };
+    let selected_format = use_state(|| initial_format);
+
+    {
+        let selected_format = selected_format.clone();
+        let mime_type = props.image_data.mime_type.clone();
+        use_effect_with(mime_type.clone(), move |_| {
+            if mime_type == "image/png" {
+                selected_format.set("png".to_string());
+            } else {
+                selected_format.set("jpeg".to_string());
+            }
+            || ()
+        });
+    }
 
     let download_cleaned_image_cb = {
         let data = props.image_data.clone();

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -31,6 +31,7 @@ pub async fn process_file(file: File) -> Result<ImageData, JsValue> {
     Ok(ImageData {
         name,
         size,
+        mime_type: mime_type.clone(),
         data_url,
         width: Some(width),
         height: Some(height),

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,8 @@ use std::collections::{HashMap, HashSet};
 pub struct ImageData {
     pub name: String,
     pub size: u64,
+    #[serde(skip)]
+    pub mime_type: String,
     #[serde(skip)] // Don't include data URL in exports
     pub data_url: String,
     pub width: Option<u32>,
@@ -32,6 +34,7 @@ impl ImageData {
         Self {
             name: self.name.clone(),
             size: if include_basic_info { self.size } else { 0 },
+            mime_type: self.mime_type.clone(),
             data_url: self.data_url.clone(), // Always keep for display
             width: if include_basic_info { self.width } else { None },
             height: if include_basic_info {


### PR DESCRIPTION
## Summary
- track each image's MIME type
- default the cleaner format to PNG when uploading a PNG image

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68557c11331c832ea26dd293fe486935