### PR TITLE
feat(image_cleaner): add WebP/GIF export options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["multimedia::images", "web-programming", "wasm"]
 authors = ["Image Metadata Extractor Contributors"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ This automatically runs code checks, formatting, and linting on every commit, en
 - **PNG**: Lossless format for maximum quality retention
 - **WebP**: Modern format for smaller file sizes
 - **GIF**: Basic format for simple animations or compatibility
-- **Format conversion**: Input PNG/GIF/WebP → Output JPEG/PNG/GIF/WebP
+- **Format conversion**: Input JPEG/PNG/GIF/WebP → Output JPEG/PNG/GIF/WebP
 
 ## Features in Detail
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ This automatically runs code checks, formatting, and linting on every commit, en
 ### Cleaned Image Formats
 - **JPEG**: Adjustable quality (30%-100%) for size optimization
 - **PNG**: Lossless format for maximum quality retention
-- **Format conversion**: Input PNG → Output JPEG or Input JPEG → Output PNG
+- **WebP**: Modern format for smaller file sizes
+- **GIF**: Basic format for simple animations or compatibility
+- **Format conversion**: Input PNG/GIF/WebP → Output JPEG/PNG/GIF/WebP
 
 ## Features in Detail
 

--- a/src/components/image_cleaner.rs
+++ b/src/components/image_cleaner.rs
@@ -13,6 +13,10 @@ pub fn image_cleaner(props: &ImageCleanerProps) -> Html {
     let image_quality = use_state(|| 0.9);
     let initial_format = if props.image_data.mime_type.starts_with("image/png") {
         "png".to_string()
+    } else if props.image_data.mime_type.starts_with("image/webp") {
+        "webp".to_string()
+    } else if props.image_data.mime_type.starts_with("image/gif") {
+        "gif".to_string()
     } else {
         "jpeg".to_string()
     };
@@ -23,8 +27,11 @@ pub fn image_cleaner(props: &ImageCleanerProps) -> Html {
         let mime_type = props.image_data.mime_type.clone();
         use_effect_with(mime_type.clone(), move |_| {
             if mime_type.starts_with("image/png") {
-
                 selected_format.set("png".to_string());
+            } else if mime_type.starts_with("image/webp") {
+                selected_format.set("webp".to_string());
+            } else if mime_type.starts_with("image/gif") {
+                selected_format.set("gif".to_string());
             } else {
                 selected_format.set("jpeg".to_string());
             }
@@ -130,6 +137,8 @@ fn format_selector(props: &FormatSelectorProps) -> Html {
             >
                 <option value="jpeg" selected={props.selected_format == "jpeg"}>{"JPEG (smaller file)"}</option>
                 <option value="png" selected={props.selected_format == "png"}>{"PNG (lossless)"}</option>
+                <option value="webp" selected={props.selected_format == "webp"}>{"WebP"}</option>
+                <option value="gif" selected={props.selected_format == "gif"}>{"GIF"}</option>
             </select>
         </label>
     }

--- a/src/image_cleaner.rs
+++ b/src/image_cleaner.rs
@@ -2,6 +2,15 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlImageElement};
 
+pub fn output_format(format: &str) -> (&'static str, &'static str) {
+    match format {
+        "png" => ("image/png", "png"),
+        "webp" => ("image/webp", "webp"),
+        "gif" => ("image/gif", "gif"),
+        _ => ("image/jpeg", "jpg"),
+    }
+}
+
 pub async fn create_cleaned_image(
     image_data_url: &str,
     filename: &str,
@@ -55,10 +64,7 @@ pub async fn create_cleaned_image(
     context.draw_image_with_html_image_element(&img, 0.0, 0.0)?;
 
     // Determine output format and extension based on user selection
-    let (mime_type, extension) = match format {
-        "png" => ("image/png", "png"),
-        _ => ("image/jpeg", "jpg"), // Default to JPEG for any other format
-    };
+    let (mime_type, extension) = output_format(format);
 
     // Get the data URL for download
     let data_url = if mime_type == "image/jpeg" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod app;
 mod components;
 mod exif;
 mod export;
-mod image_cleaner;
+pub mod image_cleaner;
 mod metadata_info;
 mod types;
 mod utils;

--- a/tests/component_tests.rs
+++ b/tests/component_tests.rs
@@ -71,3 +71,14 @@ fn test_component_lifecycle_safety() {
     // If we reach here without panicking, the test passes
     assert!(true);
 }
+
+#[test]
+#[allow(dead_code)]
+fn test_output_format_mapping() {
+    use image_metadata_extractor::image_cleaner::output_format;
+
+    assert_eq!(output_format("webp"), ("image/webp", "webp"));
+    assert_eq!(output_format("gif"), ("image/gif", "gif"));
+    assert_eq!(output_format("png"), ("image/png", "png"));
+    assert_eq!(output_format("anything"), ("image/jpeg", "jpg"));
+}


### PR DESCRIPTION
## Summary
- allow exporting cleaned images in WebP and GIF
- expose output format helper and test it
- document WebP and GIF as supported download formats

## Testing
- `make check`
- `make test`
- `make lint`
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_6855966497a4832e83e6b7cdb46543a6