### PR TITLE
feat: improve unsupported file handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,11 +13,13 @@ pub fn app() -> Html {
     let selected_metadata = use_state(HashSet::<String>::new);
     let show_explanations = use_state(|| false);
     let file_input_trigger = use_state(|| None::<Callback<()>>);
+    let error_message = use_state(|| None::<String>);
 
     let on_file_loaded = {
         let image_data = image_data.clone();
         let is_expanded = is_expanded.clone();
         let selected_metadata = selected_metadata.clone();
+        let error_message = error_message.clone();
 
         Callback::from(move |data: ImageData| {
             // Auto-select all metadata by default
@@ -25,6 +27,14 @@ pub fn app() -> Html {
             selected_metadata.set(all_keys);
             image_data.set(Some(data));
             is_expanded.set(false); // Reset to thumbnail view
+            error_message.set(None);
+        })
+    };
+
+    let on_file_error = {
+        let error_message = error_message.clone();
+        Callback::from(move |msg: String| {
+            error_message.set(Some(msg));
         })
     };
 
@@ -78,10 +88,16 @@ pub fn app() -> Html {
         <div style="min-height: 100vh; display: flex; flex-direction: column;">
             <div style="max-width: 800px; margin: 0 auto; padding: 16px; flex: 1;">
                 <h1>{"File Metadata Extractor"}</h1>
+                {
+                    if let Some(msg) = &*error_message {
+                        html! { <p style="color: red;">{msg}</p> }
+                    } else { html!{} }
+                }
 
                 <FileUpload
                     on_file_loaded={on_file_loaded}
                     trigger_file_input={on_trigger_file_input}
+                    on_error={on_file_error}
                 />
 
                 // Main content area with consistent layout

--- a/src/components/image_cleaner.rs
+++ b/src/components/image_cleaner.rs
@@ -11,7 +11,6 @@ pub struct ImageCleanerProps {
 
 #[function_component(ImageCleaner)]
 pub fn image_cleaner(props: &ImageCleanerProps) -> Html {
-
     let download_cleaned_image_cb = {
         let data = props.image_data.clone();
 
@@ -25,22 +24,31 @@ pub fn image_cleaner(props: &ImageCleanerProps) -> Html {
                     if let Some(base64_data) = data_url.strip_prefix("data:image/") {
                         if let Some(comma_pos) = base64_data.find(',') {
                             let base64_content = &base64_data[comma_pos + 1..];
-                            if let Ok(file_bytes) = general_purpose::STANDARD.decode(base64_content) {
+                            if let Ok(file_bytes) = general_purpose::STANDARD.decode(base64_content)
+                            {
                                 match BinaryCleaner::clean_metadata(&file_bytes, file_extension) {
                                     Ok(cleaned_bytes) => {
                                         // Create cleaned filename
                                         let cleaned_filename = filename
                                             .strip_suffix(&format!(".{}", file_extension))
                                             .unwrap_or(&filename)
-                                            .to_string() + "_cleaned." + file_extension;
-                                        
+                                            .to_string()
+                                            + "_cleaned."
+                                            + file_extension;
+
                                         // Download cleaned file
                                         let mime_type = format!("image/{}", file_extension);
-                                        download_binary_file(&cleaned_bytes, &cleaned_filename, &mime_type);
+                                        download_binary_file(
+                                            &cleaned_bytes,
+                                            &cleaned_filename,
+                                            &mime_type,
+                                        );
                                         return;
                                     }
                                     Err(e) => {
-                                        web_sys::console::log_1(&format!("Binary cleaning failed: {}", e).into());
+                                        web_sys::console::log_1(
+                                            &format!("Binary cleaning failed: {}", e).into(),
+                                        );
                                         return;
                                     }
                                 }
@@ -48,7 +56,7 @@ pub fn image_cleaner(props: &ImageCleanerProps) -> Html {
                         }
                     }
                 }
-                
+
                 web_sys::console::log_1(&"Failed to process file for binary cleaning".into());
             });
         })

--- a/src/components/metadata_display.rs
+++ b/src/components/metadata_display.rs
@@ -91,7 +91,7 @@ pub fn metadata_display(props: &MetadataDisplayProps) -> Html {
                         let category_keys: HashSet<String> = items.iter().map(|(key, _)| (*key).clone()).collect();
                         let category_selected_count = category_keys.iter().filter(|key| selected_metadata.contains(*key)).count();
                         let _all_category_selected = category_selected_count == category_keys.len();
-                        
+
                         html! {
                             <div key={*category} style="margin-bottom: 20px;">
                                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; border-bottom: 1px solid #ddd; padding-bottom: 5px;">

--- a/src/components/metadata_export.rs
+++ b/src/components/metadata_export.rs
@@ -74,7 +74,11 @@ pub fn metadata_export(props: &MetadataExportProps) -> Html {
     };
 
     // Only show export section if there's metadata to export
-    if data.exif_data.is_empty() && data.gps_coords.is_none() && data.width.is_none() && data.height.is_none() {
+    if data.exif_data.is_empty()
+        && data.gps_coords.is_none()
+        && data.width.is_none()
+        && data.height.is_none()
+    {
         return html! {};
     }
 

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -49,6 +49,23 @@ pub async fn process_file(file: File) -> Result<ImageData, JsValue> {
         };
     }
 
+    // Verify that we recognize this mime type
+    let supported_types = [
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "application/pdf",
+        "image/svg+xml",
+        "image/tiff",
+        "image/heif",
+        "image/avif",
+        "image/jxl",
+    ];
+    if !supported_types.contains(&mime_type.as_str()) {
+        return Err(JsValue::from_str("Unsupported file type"));
+    }
+
     // Create data URL
     let data_url = format!("data:{};base64,{}", mime_type, base64_encode(&bytes));
 

--- a/src/image_cleaner.rs
+++ b/src/image_cleaner.rs
@@ -1,0 +1,8 @@
+pub fn output_format(format: &str) -> (&'static str, &'static str) {
+    match format.to_lowercase().as_str() {
+        "webp" => ("image/webp", "webp"),
+        "gif" => ("image/gif", "gif"),
+        "png" => ("image/png", "png"),
+        _ => ("image/jpeg", "jpg"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 mod app;
 mod binary_cleaner;
 mod components;
-mod exif;
+pub mod exif;
 mod export;
+pub mod image_cleaner;
 mod metadata_info;
 mod types;
 mod utils;

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,7 +42,11 @@ impl ImageData {
         }
 
         Self {
-            name: if include_basic_info { self.name.clone() } else { String::new() },
+            name: if include_basic_info {
+                self.name.clone()
+            } else {
+                String::new()
+            },
             size: if include_basic_info { self.size } else { 0 },
             mime_type: self.mime_type.clone(),
             data_url: self.data_url.clone(), // Always keep for display

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,7 +75,8 @@ pub fn download_binary_file(bytes: &[u8], filename: &str, mime_type: &str) {
     let blob_options = web_sys::BlobPropertyBag::new();
     blob_options.set_type(mime_type);
 
-    let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(&blob_parts, &blob_options).unwrap();
+    let blob =
+        web_sys::Blob::new_with_u8_array_sequence_and_options(&blob_parts, &blob_options).unwrap();
 
     let url = Url::create_object_url_with_blob(&blob).unwrap();
 

--- a/tests/component_tests.rs
+++ b/tests/component_tests.rs
@@ -82,3 +82,21 @@ fn test_output_format_mapping() {
     assert_eq!(output_format("png"), ("image/png", "png"));
     assert_eq!(output_format("anything"), ("image/jpeg", "jpg"));
 }
+
+#[wasm_bindgen_test]
+async fn test_unsupported_file_error() {
+    use image_metadata_extractor::exif::process_file;
+    use js_sys::{Array, Uint8Array};
+    use web_sys::File;
+
+    let bytes = Uint8Array::new_with_length(4);
+    bytes.copy_from(&[1, 2, 3, 4]);
+    let mut parts = Array::new();
+    parts.push(&bytes.buffer());
+    let mut bag = web_sys::FilePropertyBag::new();
+    bag.type_("application/octet-stream");
+    let file = File::new_with_u8_array_sequence_and_options(&parts, "test.bin", &bag).unwrap();
+
+    let result = process_file(file).await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- detect unsupported file types in EXIF processing
- surface errors through `FileUpload` and `App`
- expose `exif` module and add simple `output_format` helper
- add wasm test covering unsupported file uploads

## Testing
- `make check`
- `make test`
- `make test-wasm` *(fails: failed to download chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_6855b5e96708832e97dc837a1aeeb8df