### PR TITLE
Add Apple Maps and OpenStreetMap links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This application allows users to upload images and extract comprehensive metadat
 
 ### 📋 **Metadata Extraction**
 - **EXIF data**: Camera settings, timestamps, camera model, lens info, etc.
-- **GPS coordinates**: Location data with Google Maps integration
+- **GPS coordinates**: Location data with Google Maps, Apple Maps, and OpenStreetMap links
 - **Image dimensions**: Width, height, and technical specifications
 - **File information**: Size, format, and basic properties
 - **Categorized display**: Organized by Camera Settings, GPS, Technical, etc.
@@ -227,7 +227,7 @@ This automatically runs code checks, formatting, and linting on every commit, en
 - **Camera Information**: Make, model, lens details
 - **Shooting Parameters**: ISO, aperture, shutter speed, focal length
 - **Timestamps**: Creation date, modification date
-- **GPS Location**: Latitude, longitude with Google Maps links
+- **GPS Location**: Latitude, longitude with Google Maps, Apple Maps, and OpenStreetMap links
 - **Technical Details**: Color space, orientation, resolution
 - **Software Information**: Camera firmware, editing software
 - **Organized categories**: Alphabetically sorted for consistent display

--- a/src/components/image_display.rs
+++ b/src/components/image_display.rs
@@ -114,7 +114,13 @@ pub fn image_display(props: &ImageDisplayProps) -> Html {
                             <h3>{"GPS Location"}</h3>
                             <p><strong>{"Latitude: "}</strong>{lat}</p>
                             <p><strong>{"Longitude: "}</strong>{lon}</p>
-                            <p><a href={format!("https://maps.google.com/maps?q={},{}", lat, lon)} target="_blank">{"View on Google Maps"}</a></p>
+                            <p>
+                                <a href={format!("https://maps.google.com/maps?q={},{}", lat, lon)} target="_blank">{"Google Maps"}</a>
+                                {" | "}
+                                <a href={format!("https://maps.apple.com/?ll={},{}", lat, lon)} target="_blank">{"Apple Maps"}</a>
+                                {" | "}
+                                <a href={format!("https://www.openstreetmap.org/?mlat={}&mlon={}", lat, lon)} target="_blank">{"OpenStreetMap"}</a>
+                            </p>
                         </div>
                     }
                 } else {

--- a/src/export.rs
+++ b/src/export.rs
@@ -56,7 +56,15 @@ pub fn generate_txt(data: &ImageData) -> String {
         txt.push_str(&format!("Latitude: {}\n", lat));
         txt.push_str(&format!("Longitude: {}\n", lon));
         txt.push_str(&format!(
-            "Google Maps: https://maps.google.com/maps?q={},{}\n\n",
+            "Google Maps: https://maps.google.com/maps?q={},{}\n",
+            lat, lon
+        ));
+        txt.push_str(&format!(
+            "Apple Maps: https://maps.apple.com/?ll={},{}\n",
+            lat, lon
+        ));
+        txt.push_str(&format!(
+            "OpenStreetMap: https://www.openstreetmap.org/?mlat={}&mlon={}\n\n",
             lat, lon
         ));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,10 @@ mod app;
 mod binary_cleaner;
 mod components;
 pub mod exif;
-mod export;
+pub mod export;
 pub mod image_cleaner;
 mod metadata_info;
-mod types;
+pub mod types;
 mod utils;
 
 use app::App;

--- a/tests/component_tests.rs
+++ b/tests/component_tests.rs
@@ -79,6 +79,29 @@ fn test_output_format_placeholder() {
     assert_eq!(1 + 1, 2);
 }
 
+#[test]
+fn test_generate_txt_includes_map_links() {
+    use image_metadata_extractor::export::generate_txt;
+    use image_metadata_extractor::types::ImageData;
+    use std::collections::HashMap;
+
+    let data = ImageData {
+        name: "test.jpg".to_string(),
+        size: 123,
+        mime_type: "image/jpeg".to_string(),
+        data_url: String::new(),
+        width: None,
+        height: None,
+        exif_data: HashMap::new(),
+        gps_coords: Some((10.0, 20.0)),
+    };
+
+    let txt = generate_txt(&data);
+    assert!(txt.contains("Google Maps"));
+    assert!(txt.contains("Apple Maps"));
+    assert!(txt.contains("OpenStreetMap"));
+}
+
 #[wasm_bindgen_test]
 async fn test_unsupported_file_error() {
     use image_metadata_extractor::exif::process_file;


### PR DESCRIPTION
## Summary
- show links to Google Maps, Apple Maps and OpenStreetMap when GPS data is present
- export GPS map links in text export
- document map link availability in README
- expose `export` and `types` modules for testing
- verify generated text export contains all map links

## Testing
- `make format`
- `make check`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855cd1faf50832e8c2cf6a454cb68df