### PR TITLE
Add CI coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,10 @@ jobs:
         run: make build
       - name: Run tests
         run: make test
+      - name: Generate coverage
+        run: make coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: target/llvm-cov/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Run tests
         run: make test
       - name: Generate coverage
-        run: make coverage
+        run: |
+          make coverage
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate coverage
         run: make coverage
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: target/llvm-cov/html

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ lint:
 # Generate code coverage report
 coverage:
 	@echo "📈 Generating coverage report..."
-	cargo test --no-run --all-features
-	cargo llvm-cov --html
+	cargo install cargo-llvm-cov --version 0.6.0
+	cargo llvm-cov
 	@echo "✅ Coverage report generated!"
 
 # Format code

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ This automatically runs code checks, formatting, and linting on every commit, en
 - All commits automatically run pre-commit hooks (install with `make setup-hooks`)
 - Code must pass `cargo check`, `cargo fmt`, and `cargo clippy`
 - Use the Makefile commands for consistent development workflows
+- CI publishes an HTML coverage report for each pull request
 - Follow the modular component architecture established in `src/components/`
 
 ### Development Workflow


### PR DESCRIPTION
## Summary
- publish coverage artifact in GitHub Actions
- document coverage artifact in README

## Testing
- `make check`
- `make test`
- `make format`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6855dd081f5c832e8cf473a3d0abbb20