### PR TITLE
Fix warnings from cargo fix

### DIFF
--- a/tests/wasm/component_tests.rs
+++ b/tests/wasm/component_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use std::collections::HashMap;
 use wasm_bindgen_test::*;
 use yew::prelude::*;

--- a/tests/wasm/components/file_upload_tests.rs
+++ b/tests/wasm/components/file_upload_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use image_metadata_extractor::components::file_upload::{FileUpload, FileUploadProps};
 use wasm_bindgen_test::*;
 use yew::prelude::*;

--- a/tests/wasm/integration_tests.rs
+++ b/tests/wasm/integration_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use image_metadata_extractor::exif::process_file;
 use js_sys::{Array, Uint8Array};
 use wasm_bindgen_test::*;


### PR DESCRIPTION
## Summary
- silence `dead_code` warnings in wasm tests

## Testing
- `make format`
- `make lint`
- `make check`
- `make test`
- `cargo fix --all-targets`
- `cargo fix --all-targets --target wasm32-unknown-unknown --allow-dirty`


------
https://chatgpt.com/codex/tasks/task_e_6856f81764dc832e88f4b328e6ed641c