### PR TITLE
Add wasm tests for App component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97563d71863fb2824b2e974e754a81d19c4a7ec47b09ced8a0e6656b6d54bd1f"
 dependencies = [
+ "futures-channel",
  "gloo-events 0.2.0",
  "js-sys",
  "wasm-bindgen",
@@ -692,6 +693,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
+ "futures-channel",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -814,6 +817,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "cargo-llvm-cov",
+ "gloo 0.10.0",
  "gloo-file 0.3.0",
  "image",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ gloo-file = "0.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-gloo = { version = "0.10", features = ["futures", "utils"] }
+gloo = { version = "0.10", features = ["futures", "utils", "timers"] }
 
 # Test configurations
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ gloo-file = "0.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+gloo = { version = "0.10", features = ["futures", "utils"] }
 
 # Test configurations
 [[test]]
@@ -48,6 +49,10 @@ path = "tests/wasm/components/file_upload_tests.rs"
 [[test]]
 name = "wasm_integration_tests"
 path = "tests/wasm/integration_tests.rs"
+
+[[test]]
+name = "app_tests"
+path = "tests/wasm/app_tests.rs"
 
 # Only include cargo-llvm-cov for non-WASM targets (Unix/Linux systems)
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/Makefile
+++ b/Makefile
@@ -78,22 +78,22 @@ test: build
 # Run WebAssembly tests in browser (Chrome - most reliable)
 test-wasm:
 	@echo "🌐 Running WebAssembly tests in browser..."
-	wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests
+	wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests --test app_tests
 	@echo "✅ WebAssembly tests complete!"
 
 # Run WebAssembly tests across multiple browsers (requires all drivers)
 test-wasm-all-browsers:
 	@echo "🌐 Attempting WebAssembly tests across all browsers..."
 	@echo "Note: This requires Chrome, Firefox, and Safari drivers to be installed"
-	wasm-pack test --headless --chrome --firefox --safari -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests || \
-	(echo "⚠️  Some browsers failed. Falling back to Chrome only..." && \
-	 wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests)
+	wasm-pack test --headless --chrome --firefox --safari -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests --test app_tests || \
+        (echo "⚠️  Some browsers failed. Falling back to Chrome only..." && \
+	wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests --test app_tests)
 	@echo "✅ Multi-browser WebAssembly tests complete!"
 
 # Run WebAssembly tests in Chrome only (fast option)
 test-wasm-chrome:
 	@echo "🌐 Running WebAssembly tests in Chrome..."
-	wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests
+	wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests --test app_tests
 	@echo "✅ Chrome WebAssembly tests complete!"
 
 # Skip WASM tests (for environments without Chrome)
@@ -105,10 +105,10 @@ test-wasm-skip:
 # Try Chrome, skip WASM tests if Chrome fails  
 test-wasm-fallback:
 	@echo "🌐 Attempting WebAssembly tests in Chrome..."
-	wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests || \
-	(echo "⚠️  Chrome failed, skipping WASM tests..." && \
-	 echo "💡 WASM tests require browser environment" && \
-	 echo "✅ Use './scripts/install-chrome-apt.sh' to install Chrome")
+	wasm-pack test --headless --chrome -- --test wasm_component_tests --test wasm_file_upload_tests --test wasm_integration_tests --test app_tests || \
+        (echo "⚠️  Chrome failed, skipping WASM tests..." && \
+         echo "💡 WASM tests require browser environment" && \
+         echo "✅ Use './scripts/install-chrome-apt.sh' to install Chrome")
 	@echo "✅ Test run complete!"
 
 # Run all tests (standard + WebAssembly across all browsers)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod app;
+pub mod app;
 mod binary_cleaner;
 pub mod components;
 pub mod exif;

--- a/tests/wasm/app_tests.rs
+++ b/tests/wasm/app_tests.rs
@@ -1,0 +1,33 @@
+use gloo::utils::document;
+use image_metadata_extractor::app::App;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use yew::prelude::*;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn test_app_renders_heading_and_placeholder() {
+    let div = document().create_element("div").unwrap();
+    document().body().unwrap().append_child(&div).unwrap();
+
+    yew::Renderer::<App>::with_root(div.clone().unchecked_into()).render();
+    gloo::timers::future::TimeoutFuture::new(0).await;
+
+    let html = div.inner_html();
+    assert!(html.contains("File Metadata Extractor"));
+    assert!(html.contains("Click here to select a file"));
+}
+
+#[wasm_bindgen_test]
+async fn test_app_footer_present() {
+    let div = document().create_element("div").unwrap();
+    document().body().unwrap().append_child(&div).unwrap();
+
+    yew::Renderer::<App>::with_root(div.clone().unchecked_into()).render();
+    gloo::timers::future::TimeoutFuture::new(0).await;
+
+    let html = div.inner_html();
+    assert!(html.contains("Privacy-First"));
+    assert!(html.contains("Open Source"));
+}


### PR DESCRIPTION
## Summary
- expose `app` module so integration tests can use the component
- add WebAssembly tests for the main `App` component
- include the new test target in `Cargo.toml`
- update Makefile to run `app_tests` when executing wasm tests

## Testing
- `make check`
- `make lint`
- `make test`
- `make test-wasm`


------
https://chatgpt.com/codex/tasks/task_e_6856f7e2b6b8832eb25d15b5fd710de5